### PR TITLE
Expose Fl::event_key(int key)

### DIFF
--- a/include/cfl.h
+++ b/include/cfl.h
@@ -29,6 +29,8 @@ int Fl_event(void);
 
 int Fl_event_key(void);
 
+int Fl_event_key_down(int);
+
 const char *Fl_event_text(void);
 
 int Fl_event_button(void);

--- a/src/cfl.cpp
+++ b/src/cfl.cpp
@@ -74,6 +74,10 @@ int Fl_event_key(void) {
     return Fl::event_key();
 }
 
+int Fl_event_key_down(int key) {
+    return Fl::event_key(key);
+}
+
 const char *Fl_event_text(void) {
     return Fl::event_text();
 }


### PR DESCRIPTION
Fl::event_key() is overloaded with a version that takes a key and returns true if the given key was held down (or pressed) during the last event. This makes it easier for games to check the current state of the key without waiting for a repeat event.