### PR TITLE
Add Fl_Input_Choice_input

### DIFF
--- a/include/cfl_misc.h
+++ b/include/cfl_misc.h
@@ -209,6 +209,8 @@ void Fl_Input_Choice_set_value(Fl_Input_Choice *self, const char *val);
 
 void Fl_Input_Choice_set_value2(Fl_Input_Choice *self, int val);
 
+void *Fl_Input_Choice_input(Fl_Input_Choice *self);
+
 void *Fl_Input_Choice_menu_button(Fl_Input_Choice *self);
 
 void Fl_Input_Choice_set_text_color(Fl_Input_Choice *self, unsigned int c);

--- a/src/cfl_misc.cpp
+++ b/src/cfl_misc.cpp
@@ -410,6 +410,10 @@ void Fl_Input_Choice_set_value2(Fl_Input_Choice *self, int val) {
     LOCK(self->value(val));
 }
 
+void *Fl_Input_Choice_input(Fl_Input_Choice *self) {
+    return self->input();
+}
+
 void *Fl_Input_Choice_menu_button(Fl_Input_Choice *self) {
     return self->menubutton();
 }


### PR DESCRIPTION
Add [`Fl_Input_Choice_input` function][1], which returns a pointer to the internal `Fl_Input` widget.

[1]: https://www.fltk.org/doc-1.3/classFl__Input__Choice.html#a7e863b5c9a096f52a9502619d11a7cd0