### PR TITLE
Fix Fl_Tooltip_current link error

### DIFF
--- a/src/cfl_misc.cpp
+++ b/src/cfl_misc.cpp
@@ -263,7 +263,7 @@ void *Fl_Tooltip_current_widget(void) {
     return ret;
 }
 
-void Fl_Tooltip_set_current_widget(Fl_Widget *w) {
+void Fl_Tooltip_current(Fl_Widget *w) {
     LOCK(Fl_Tooltip::current(w));
 }
 


### PR DESCRIPTION
The `Fl_Tooltip_current` function is declared in the header, but its definition in the `.cpp` file has an incorrect name.