### PR TITLE
Two small additions

### DIFF
--- a/include/cfl.h
+++ b/include/cfl.h
@@ -71,6 +71,10 @@ int Fl_event_length(void);
 
 int Fl_event_state(void);
 
+int Fl_w(void);
+
+int Fl_h(void);
+
 int Fl_screen_x(void);
 
 int Fl_screen_y(void);

--- a/include/cfl_window.h
+++ b/include/cfl_window.h
@@ -61,6 +61,8 @@ GROUP_DECLARE(Fl_Window)
 
 WINDOW_DECLARE(Fl_Window)
 
+Fl_Window *Fl_Window_new_wh(int width, int height, const char *title);
+
 Fl_Window *Fl_Window_find_by_handle(void *handle);
 
 winid resolve_raw_handle(void *handle);

--- a/src/cfl.cpp
+++ b/src/cfl.cpp
@@ -173,6 +173,14 @@ int Fl_event_state(void) {
     return Fl::event_state();
 }
 
+int Fl_w(void) {
+    return Fl::w();
+}
+
+int Fl_h(void) {
+    return Fl::h();
+}
+
 int Fl_screen_x(void) {
     return Fl::x();
 }

--- a/src/cfl_window.cpp
+++ b/src/cfl_window.cpp
@@ -254,6 +254,11 @@ GROUP_DEFINE(Fl_Window)
 
 WINDOW_DEFINE(Fl_Window)
 
+Fl_Window *Fl_Window_new_wh(int width, int height, const char *title) {
+	LOCK(auto ret = new Fl_Window(width, height, title));
+	return ret;
+}
+
 Fl_Window *Fl_Window_find_by_handle(void *handle) {
     LOCK(auto ret = fl_find(*(Window *)handle));
     return ret;


### PR DESCRIPTION
First exposes Fl::w() and Fl::h()

Second adds a new wrapper around Fl_Window constructor to only take width,height - without that, I'm not sure how you create window without forcing a position.