### PR TITLE
Add Fl__Input_ cursor_color

### DIFF
--- a/include/cfl_input.h
+++ b/include/cfl_input.h
@@ -22,6 +22,8 @@ extern "C" {
     int widget##_copy(widget *, int clipboard);                                                    \
     int widget##_undo(widget *);                                                                   \
     int widget##_copy_cuts(widget *);                                                              \
+    unsigned int widget##_cursor_color(widget *);                                                  \
+    void widget##_set_cursor_color(widget *, unsigned int s);                                      \
     int widget##_text_font(widget *);                                                              \
     void widget##_set_text_font(widget *, int s);                                                  \
     unsigned int widget##_text_color(widget *);                                                    \

--- a/src/cfl_input.cpp
+++ b/src/cfl_input.cpp
@@ -70,6 +70,13 @@
         LOCK(auto ret = self->cut());                                                              \
         return ret;                                                                                \
     }                                                                                              \
+    unsigned int widget##_cursor_color(widget *self) {                                             \
+        LOCK(auto ret = self->cursor_color());                                                     \
+        return ret;                                                                                \
+    }                                                                                              \
+    void widget##_set_cursor_color(widget *self, unsigned int s) {                                 \
+        LOCK(self->cursor_color(s));                                                               \
+    }                                                                                              \
     int widget##_text_font(widget *self) {                                                         \
         LOCK(auto ret = self->textfont());                                                         \
         return ret;                                                                                \


### PR DESCRIPTION
As per the [docs](https://www.fltk.org/doc-1.4/classFl__Input__.html#ae68497561460ba062ca75941e76e17e8), adds getters and setters for the cursor color.
