### PR TITLE
Remove Utf8Char:attr_color method to track change in Fl_Terminal widget

### DIFF
--- a/include/cfl_group.h
+++ b/include/cfl_group.h
@@ -377,9 +377,6 @@ typedef void Fl_Terminal_Utf8Char;
 unsigned Fl_Terminal_Utf8Char_attr_bgcolor(
     Fl_Terminal_Utf8Char const *self, const Fl_Terminal *grp); // Actually returns Fl_Color
 
-unsigned Fl_Terminal_Utf8Char_attr_color(
-    Fl_Terminal_Utf8Char const *self, unsigned col, const Fl_Terminal *grp); // Actually takes and returns Fl_Color
-
 unsigned Fl_Terminal_Utf8Char_attr_fgcolor(
     Fl_Terminal_Utf8Char const *self, const Fl_Terminal *grp); // Actually returns Fl_Color
 

--- a/src/cfl_group.cpp
+++ b/src/cfl_group.cpp
@@ -344,7 +344,6 @@ struct Fl_Terminal_Derived : public Widget_Derived<Fl_Terminal> {
             return x;
         };
         unsigned attr_bgcolor(Fl_Terminal const *grp) const { return ((Fl_Terminal::Utf8Char *) this)->attr_bg_color(grp); };
-        unsigned attr_color(unsigned col, Fl_Terminal const *grp) const { return ((Fl_Terminal::Utf8Char *) this)->attr_color(col, grp); };
         unsigned attr_fgcolor(Fl_Terminal const *grp) const { return ((Fl_Terminal::Utf8Char *) this)->attr_fg_color(grp); };
         unsigned char attrib(void) const {
             return ((Fl_Terminal::Utf8Char *) this)->attrib(); 
@@ -974,15 +973,6 @@ int Fl_Terminal_get_selection(Fl_Terminal const *self, int *results) {
 unsigned Fl_Terminal_Utf8Char_attr_bgcolor(Fl_Terminal_Utf8Char const *self, Fl_Terminal const *grp) { // Actually returns Fl_Color
     auto self1 = (Fl_Terminal_Derived::Utf8Char *) self;
     LOCK(auto ret = self1->attr_bgcolor(grp));
-    return ret;
-}
-
-/// Get the color `col` possibly influenced by BOLD or DIM.
-///    If a `grp` widget is specified (i.e. not `NULL`), don't let the color `col` be
-///    influenced by the attribute bits *if* it matches the `grp` widget's own color().
-unsigned Fl_Terminal_Utf8Char_attr_color(Fl_Terminal_Utf8Char const *self, unsigned col, Fl_Terminal const *grp) { // Actually returns Fl_Color
-    auto self1 = (Fl_Terminal_Derived::Utf8Char *) self;
-    LOCK(auto ret = self1->attr_color((Fl_Color) col, grp));
     return ret;
 }
 


### PR DESCRIPTION
Remove `Utf8Char::attr_color `method to track change in fltk.

This PR is needed to support the corresponding PR in fltk_rs