### PR TITLE
update CMake so that examples are built with the appropriate flag for…

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,6 +18,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(FLTK_BACKEND_X11 ON CACHE BOOL " " FORCE)
 endif()
 
+set(CMAKE_CXX_STANDARD 14)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. cfltk)
 
 add_executable(hello hello.c)


### PR DESCRIPTION
the two threads examples use `std::chrono` which requires c++14 (at least on macOS)