### PR TITLE
fix Fl_FlexType enums and fix examples for libcfltk2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,25 +22,25 @@ set(CMAKE_CXX_STANDARD 14)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. cfltk)
 
 add_executable(hello hello.c)
-target_link_libraries(hello PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(hello PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)
 
 add_executable(img img.c)
-target_link_libraries(img PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(img PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)
 
 add_executable(handler handler.c)
-target_link_libraries(handler PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(handler PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)
 
 add_executable(handler2 handler2.c)
-target_link_libraries(handler2 PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(handler2 PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)
 
 add_executable(counter counter.c)
-target_link_libraries(counter PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(counter PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)
 
 add_executable(threads threads.cpp)
-target_link_libraries(threads PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(threads PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)
 
 add_executable(cthreads cthreads.cpp)
-target_link_libraries(cthreads PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(cthreads PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)
 
 add_executable(deleter deleter.c)
-target_link_libraries(deleter PUBLIC cfltk fltk::fltk fltk::images fltk::png fltk::z)
+target_link_libraries(deleter PUBLIC cfltk2 fltk::fltk fltk::images fltk::png fltk::z)

--- a/examples/counter.c
+++ b/examples/counter.c
@@ -45,7 +45,7 @@ int main(void) {
     Fl_Box *count = Fl_Box_new(0, 0, 0, 0, "0");
     Fl_Box_set_align(count, Fl_Align_Top | Fl_Align_Inside);
     Fl_Flex *row = Fl_Flex_new(0, 0, 0, 0, NULL);
-    Fl_Flex_set_type(row, 1); // row
+    Fl_Flex_set_type(row, Fl_FlexType_Row);
     Fl_Flex_set_size(col, (Fl_Widget *)row, 60);
     Fl_Box_new(0, 0, 0, 0, NULL);
     Fl_Button *but =

--- a/include/cfl_enums.h
+++ b/include/cfl_enums.h
@@ -613,8 +613,8 @@ enum Fl_MenuButtonType {
 };
 
 enum Fl_FlexType {
-    Fl_FlexType_Row = 0,
-    Fl_FlexType_Column,
+    Fl_FlexType_Column = 0,
+    Fl_FlexType_Row,
 };
 
 enum Fl_RgbScaling {


### PR DESCRIPTION
Looks like the `Fl_FlexType` enums were backwards.  From Fl_Flex.H:

```c++
  enum { // values for type(int)
    VERTICAL   = 0,     ///< vertical layout (one column)
    HORIZONTAL = 1,     ///< horizontal layout (one row)
    COLUMN     = 0,     ///< alias for VERTICAL
    ROW        = 1      ///< alias for HORIZONTAL
  };
```

also updated the `counter.c` example that previously had the magic number `1` for Row

and updated the `examples/CMakeLists.txt` for the new `cfltk2` library/target name.