### PR TITLE
Fix `CMAKE_MSVC_RUNTIME_LIBRARY` to use the correct value based on Debug/Release build with `CFLTK_MSVC_CRT_STATIC` enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(MSVC)
   string(REGEX REPLACE "/EHsc" "/EHs-c-" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   add_definitions("/D_CRT_SECURE_NO_WARNINGS /wd4099 /wd4996")
   if(CFLTK_MSVC_CRT_STATIC)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Release>:Release>")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     string(REGEX REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE
                          "${CMAKE_CXX_FLAGS_RELEASE}")
     string(REGEX REPLACE "/MD" "/MT" CMAKE_C_FLAGS_RELEASE


### PR DESCRIPTION
When using `-DCFLTK_MSVC_CRT_STATIC=ON` option, CMakeLists.txt tries to set `CMAKE_MSVC_RUNTIME_LIBRARY` to this value: `MultiThreaded$<$<CONFIG:Release>:Release>`, which will result in `MultiThreadedRelease` if building in Release mode. According to the [CMake v3.28 documentation](https://cmake.org/cmake/help/v3.28/prop_tgt/MSVC_RUNTIME_LIBRARY.html#prop_tgt:MSVC_RUNTIME_LIBRARY), there's no such MSVC runtime library value as `MultiThreadedRelease`. The only allowed values are `MultiThreaded` (for Release builds) and `MultiThreadedDebug` (for, obviously, Debug builds). I couldn't build the library with static MSVC runtime library until this fix. This should be also probably backported to `fltk1.4` branch. I can open another pull request for the branch, or you can simply backport it.